### PR TITLE
feat: implement Switch method overloads for non-generic Result class (TASK-012)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -44,7 +44,7 @@
 
 ### Pattern Matching
 - [x] **TASK-011**: Implement Match method with all overloads
-- [ ] **TASK-012**: Implement Switch method for side effects
+- [x] **TASK-012**: Implement Switch method for side effects
 - [ ] **TASK-013**: Add implicit operators for seamless conversions
 - [ ] **TASK-014**: Create TryGetValue pattern for Result<T>
 - [ ] **TASK-015**: Add async-friendly extension methods


### PR DESCRIPTION
## Summary
- Implemented comprehensive Switch method overloads for non-generic Result class
- Added 14 comprehensive tests with full coverage of all switching scenarios
- Complete Task 012 with proper imperative programming pattern support

## Features Added
- `Result.Switch(Action onSuccess, Action<string> onFailure, bool includeOperationCancelledFailures = false)` - Simple imperative pattern matching
- `Result.Switch(onSuccess, onError, onSecurityException, onValidationException, onOperationCanceledException)` - Complex imperative pattern matching with specific failure type handlers
- Comprehensive XML documentation with usage examples
- Proper argument validation with meaningful exceptions
- Optional operation cancelled failure handling

## Test Coverage
- 14 new tests in ResultTests.cs covering all Switch method scenarios
- Null argument validation tests for all parameters
- Success and failure routing tests
- Complex pattern matching with specific failure type routing
- Theory-based tests for comprehensive failure type coverage
- Operation cancelled handling with and without include flag

## Technical Details  
- Follows same patterns and signatures as existing Result<T>.Switch methods
- Zero compiler warnings, all 110 tests passing
- Imperative programming pattern enables clean side-effect execution
- Proper failure type routing based on ResultFailureType enum
- Consistent with existing codebase conventions and documentation standards
- Special handling for operation cancelled failures with optional inclusion

🤖 Generated with [Claude Code](https://claude.ai/code)