### PR TITLE
feat: implement custom JsonConverter for Result<T> (TASK-018)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -52,7 +52,7 @@
 ### Serialization Support
 - [x] **TASK-016**: Add JsonConstructor and JsonInclude attributes
 - [x] **TASK-017**: Create custom JsonConverter for Result
-- [ ] **TASK-018**: Create custom JsonConverter for Result<T>
+- [x] **TASK-018**: Create custom JsonConverter for Result<T>
 - [ ] **TASK-019**: Handle ValidationProblemResponse serialization
 - [ ] **TASK-020**: Test round-trip serialization for all scenarios
 

--- a/src/Core/Serialization/ResultTJsonConverter.cs
+++ b/src/Core/Serialization/ResultTJsonConverter.cs
@@ -1,0 +1,253 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FlowRight.Core.Results;
+
+namespace FlowRight.Core.Serialization;
+
+/// <summary>
+/// Provides custom JSON serialization and deserialization for <see cref="Result{T}"/> instances.
+/// </summary>
+/// <typeparam name="T">The type of the success value that the result can contain.</typeparam>
+/// <remarks>
+/// <para>
+/// This converter ensures proper serialization of Result&lt;T&gt; objects while maintaining immutability
+/// and supporting all failure types including validation failures, security exceptions, and
+/// operation cancellations. The converter handles both serialization and deserialization
+/// in a way that preserves the exact state of Result&lt;T&gt; objects including their success values.
+/// </para>
+/// <para>
+/// The converter serializes Result&lt;T&gt; objects as JSON objects with the following structure:
+/// <code>
+/// {
+///   "value": T,
+///   "error": "string",
+///   "failures": { "field": ["error1", "error2"] },
+///   "failureType": "None|Error|Security|Validation|OperationCanceled",
+///   "resultType": "Success|Information|Warning|Error"
+/// }
+/// </code>
+/// </para>
+/// <para>
+/// For successful results, the "value" property contains the success value. For failed results,
+/// the "value" property is omitted from the JSON output.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// // Register the converter globally
+/// JsonSerializerOptions options = new()
+/// {
+///     Converters = { new ResultTJsonConverter&lt;User&gt;() }
+/// };
+/// 
+/// Result&lt;User&gt; result = Result.Success(user);
+/// string json = JsonSerializer.Serialize(result, options);
+/// Result&lt;User&gt; deserialized = JsonSerializer.Deserialize&lt;Result&lt;User&gt;&gt;(json, options);
+/// </code>
+/// </example>
+public sealed class ResultTJsonConverter<T> : JsonConverter<Result<T>>
+{
+    /// <summary>
+    /// Gets a value indicating whether this converter can convert the specified type.
+    /// </summary>
+    /// <param name="typeToConvert">The type to check for conversion capability.</param>
+    /// <returns><see langword="true"/> if the type is <see cref="Result{T}"/> of the matching generic type; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>
+    /// This converter only handles Result&lt;T&gt; where T matches the generic type parameter
+    /// specified when the converter was instantiated. Each generic Result type requires
+    /// its own converter instance.
+    /// </remarks>
+    public override bool CanConvert(Type typeToConvert) =>
+        typeToConvert == typeof(Result<T>);
+
+    /// <summary>
+    /// Deserializes a JSON object into a <see cref="Result{T}"/> instance.
+    /// </summary>
+    /// <param name="reader">The JSON reader positioned at the start of the Result&lt;T&gt; object.</param>
+    /// <param name="typeToConvert">The type to convert (should be <see cref="Result{T}"/>).</param>
+    /// <param name="options">The JSON serializer options.</param>
+    /// <returns>A <see cref="Result{T}"/> instance representing the deserialized JSON data.</returns>
+    /// <exception cref="JsonException">Thrown when the JSON structure is invalid or contains unexpected data.</exception>
+    /// <remarks>
+    /// <para>
+    /// This method reconstructs Result&lt;T&gt; objects from JSON by reading the serialized properties
+    /// and using the appropriate static factory methods to create immutable Result&lt;T&gt; instances.
+    /// The method preserves the exact failure type, error information, and success value from the original object.
+    /// </para>
+    /// <para>
+    /// The deserialization process handles all Result&lt;T&gt; states:
+    /// <list type="bullet">
+    /// <item><description>Success states with typed values and appropriate ResultType</description></item>
+    /// <item><description>General error failures</description></item>
+    /// <item><description>Security failures</description></item>
+    /// <item><description>Validation failures with field-specific errors</description></item>
+    /// <item><description>Operation cancellation failures</description></item>
+    /// </list>
+    /// </para>
+    /// <para>
+    /// When deserializing successful results, the "value" property is deserialized according to
+    /// the type T. For failed results, the value is ignored even if present in the JSON.
+    /// </para>
+    /// </remarks>
+    public override Result<T> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+        {
+            throw new JsonException("Expected StartObject token");
+        }
+
+        T? value = default;
+        string error = string.Empty;
+        Dictionary<string, string[]> failures = [];
+        ResultFailureType failureType = ResultFailureType.None;
+        ResultType resultType = ResultType.Success;
+        bool hasValue = false;
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                break;
+            }
+
+            if (reader.TokenType != JsonTokenType.PropertyName)
+            {
+                continue;
+            }
+
+            string? propertyName = reader.GetString();
+            reader.Read();
+
+            switch (propertyName?.ToLowerInvariant())
+            {
+                case "value":
+                    if (reader.TokenType != JsonTokenType.Null)
+                    {
+                        value = JsonSerializer.Deserialize<T>(ref reader, options);
+                        hasValue = true;
+                    }
+                    break;
+
+                case "error":
+                    error = reader.GetString() ?? string.Empty;
+                    break;
+
+                case "failures":
+                    if (reader.TokenType == JsonTokenType.StartObject)
+                    {
+                        failures = JsonSerializer.Deserialize<Dictionary<string, string[]>>(ref reader, options) ?? [];
+                    }
+                    break;
+
+                case "failuretype":
+                    if (reader.TokenType == JsonTokenType.String)
+                    {
+                        string? failureTypeString = reader.GetString();
+                        if (Enum.TryParse<ResultFailureType>(failureTypeString, true, out ResultFailureType parsedFailureType))
+                        {
+                            failureType = parsedFailureType;
+                        }
+                    }
+                    else if (reader.TokenType == JsonTokenType.Number)
+                    {
+                        failureType = (ResultFailureType)reader.GetInt32();
+                    }
+                    break;
+
+                case "resulttype":
+                    if (reader.TokenType == JsonTokenType.String)
+                    {
+                        string? resultTypeString = reader.GetString();
+                        if (Enum.TryParse<ResultType>(resultTypeString, true, out ResultType parsedResultType))
+                        {
+                            resultType = parsedResultType;
+                        }
+                    }
+                    else if (reader.TokenType == JsonTokenType.Number)
+                    {
+                        resultType = (ResultType)reader.GetInt32();
+                    }
+                    break;
+            }
+        }
+
+        // Reconstruct the Result<T> based on the deserialized state
+        if (string.IsNullOrEmpty(error))
+        {
+            // Success case
+            if (!hasValue)
+            {
+                // No value provided for a success result, treat as failure
+                return Result.Failure<T>("No value provided for Result<T>");
+            }
+
+            return Result.Success(value!, resultType);
+        }
+
+        // Failure cases - use appropriate factory methods based on failure type
+        return failureType switch
+        {
+            ResultFailureType.Validation when failures.Count > 0 => Result.ValidationFailure<T>(failures),
+            ResultFailureType.Security => Result.Failure<T>(new System.Security.SecurityException(error)),
+            ResultFailureType.OperationCanceled => Result.Failure<T>(new OperationCanceledException(error)),
+            _ => Result.Failure<T>(error, resultType, failureType)
+        };
+    }
+
+    /// <summary>
+    /// Serializes a <see cref="Result{T}"/> instance to JSON.
+    /// </summary>
+    /// <param name="writer">The JSON writer to write the serialized data to.</param>
+    /// <param name="value">The <see cref="Result{T}"/> instance to serialize.</param>
+    /// <param name="options">The JSON serializer options.</param>
+    /// <remarks>
+    /// <para>
+    /// This method serializes Result&lt;T&gt; objects to JSON by writing their properties as a JSON object.
+    /// The serialization preserves all error information, failure types, result states, and success values
+    /// to enable complete round-trip serialization.
+    /// </para>
+    /// <para>
+    /// The method writes the following JSON structure:
+    /// <list type="bullet">
+    /// <item><description><c>value</c>: The success value of type T (only for successful results)</description></item>
+    /// <item><description><c>error</c>: The error message string</description></item>
+    /// <item><description><c>failures</c>: Dictionary of field-specific validation errors</description></item>
+    /// <item><description><c>failureType</c>: The specific failure type enumeration</description></item>
+    /// <item><description><c>resultType</c>: The general result type enumeration</description></item>
+    /// </list>
+    /// </para>
+    /// <para>
+    /// For successful results, the "value" property is included with the success value serialized
+    /// according to type T. For failed results, the "value" property is omitted entirely.
+    /// </para>
+    /// </remarks>
+    public override void Write(Utf8JsonWriter writer, Result<T> value, JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(value);
+
+        writer.WriteStartObject();
+
+        // Write Value property only for successful results
+        if (value.IsSuccess && value.TryGetValue(out T? successValue))
+        {
+            writer.WritePropertyName("value");
+            JsonSerializer.Serialize(writer, successValue, options);
+        }
+
+        // Write Error property
+        writer.WriteString("error", value.Error);
+
+        // Write Failures property
+        writer.WritePropertyName("failures");
+        JsonSerializer.Serialize(writer, value.Failures, options);
+
+        // Write FailureType property
+        writer.WriteString("failureType", value.FailureType.ToString());
+
+        // Write ResultType property
+        writer.WriteString("resultType", value.ResultType.ToString());
+
+        writer.WriteEndObject();
+    }
+}

--- a/tests/Core.Tests/Serialization/ResultTJsonConverterTests.cs
+++ b/tests/Core.Tests/Serialization/ResultTJsonConverterTests.cs
@@ -1,0 +1,547 @@
+using System.Security;
+using System.Text.Json;
+using FlowRight.Core.Results;
+using FlowRight.Core.Serialization;
+using Shouldly;
+using Xunit;
+
+namespace FlowRight.Core.Tests.Serialization;
+
+/// <summary>
+/// Contains comprehensive tests for the <see cref="ResultTJsonConverter{T}"/> class.
+/// </summary>
+/// <remarks>
+/// These tests verify that the JsonConverter can properly serialize and deserialize
+/// all types of Result&lt;T&gt; objects while maintaining immutability and preserving all
+/// failure information as well as success values across round-trip operations.
+/// </remarks>
+public sealed class ResultTJsonConverterTests
+{
+    #region Test Infrastructure
+
+    private readonly JsonSerializerOptions _options;
+
+    public ResultTJsonConverterTests()
+    {
+        _options = new JsonSerializerOptions
+        {
+            Converters = { new ResultTJsonConverter<string>(), new ResultTJsonConverter<int>(), new ResultTJsonConverter<TestUser>() },
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+    }
+
+    public sealed record TestUser(string Name, string Email, int Age);
+
+    #endregion Test Infrastructure
+
+    #region CanConvert Tests
+
+    [Fact]
+    public void CanConvert_WithResultTType_ShouldReturnTrue()
+    {
+        // Arrange
+        ResultTJsonConverter<string> converter = new();
+
+        // Act
+        bool canConvert = converter.CanConvert(typeof(Result<string>));
+
+        // Assert
+        canConvert.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(typeof(int))]
+    [InlineData(typeof(string))]
+    [InlineData(typeof(Result))]
+    [InlineData(typeof(object))]
+    [InlineData(typeof(Result<int>))] // Different generic type
+    public void CanConvert_WithNonMatchingResultTType_ShouldReturnFalse(Type type)
+    {
+        // Arrange
+        ResultTJsonConverter<string> converter = new();
+
+        // Act
+        bool canConvert = converter.CanConvert(type);
+
+        // Assert
+        canConvert.ShouldBeFalse();
+    }
+
+    #endregion CanConvert Tests
+
+    #region Success Serialization Tests
+
+    [Fact]
+    public void Serialize_SuccessResultWithStringValue_ShouldProduceCorrectJson()
+    {
+        // Arrange
+        Result<string> result = Result.Success("Hello World");
+
+        // Act
+        string json = JsonSerializer.Serialize(result, _options);
+
+        // Assert
+        json.ShouldNotBeNullOrWhiteSpace();
+        json.ShouldContain("\"value\":\"Hello World\"");
+        json.ShouldContain("\"error\":\"\"");
+        json.ShouldContain("\"failures\":{}");
+        json.ShouldContain("\"failureType\":\"None\"");
+        json.ShouldContain("\"resultType\":\"Success\"");
+    }
+
+    [Fact]
+    public void Serialize_SuccessResultWithIntValue_ShouldProduceCorrectJson()
+    {
+        // Arrange
+        Result<int> result = Result.Success(42);
+
+        // Act
+        string json = JsonSerializer.Serialize(result, _options);
+
+        // Assert
+        json.ShouldContain("\"value\":42");
+        json.ShouldContain("\"error\":\"\"");
+        json.ShouldContain("\"failures\":{}");
+        json.ShouldContain("\"failureType\":\"None\"");
+        json.ShouldContain("\"resultType\":\"Success\"");
+    }
+
+    [Fact]
+    public void Serialize_SuccessResultWithComplexObject_ShouldProduceCorrectJson()
+    {
+        // Arrange
+        TestUser user = new("John Doe", "john@example.com", 30);
+        Result<TestUser> result = Result.Success(user);
+
+        // Act
+        string json = JsonSerializer.Serialize(result, _options);
+
+        // Assert
+        json.ShouldContain("\"name\":\"John Doe\"");
+        json.ShouldContain("\"email\":\"john@example.com\"");
+        json.ShouldContain("\"age\":30");
+        json.ShouldContain("\"error\":\"\"");
+        json.ShouldContain("\"failureType\":\"None\"");
+        json.ShouldContain("\"resultType\":\"Success\"");
+    }
+
+    [Fact]
+    public void Serialize_InformationResultWithValue_ShouldProduceCorrectJson()
+    {
+        // Arrange
+        Result<string> result = Result.Success("Info message", ResultType.Information);
+
+        // Act
+        string json = JsonSerializer.Serialize(result, _options);
+
+        // Assert
+        json.ShouldContain("\"value\":\"Info message\"");
+        json.ShouldContain("\"resultType\":\"Information\"");
+        json.ShouldContain("\"failureType\":\"None\"");
+        json.ShouldContain("\"error\":\"\"");
+    }
+
+    [Fact]
+    public void Deserialize_SuccessStringJson_ShouldCreateCorrectResult()
+    {
+        // Arrange
+        string json = @"{
+            ""value"": ""Test Value"",
+            ""error"": """",
+            ""failures"": {},
+            ""failureType"": ""None"",
+            ""resultType"": ""Success""
+        }";
+
+        // Act
+        Result<string> result = JsonSerializer.Deserialize<Result<string>>(json, _options)!;
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.IsSuccess.ShouldBeTrue();
+        result.IsFailure.ShouldBeFalse();
+        result.ResultType.ShouldBe(ResultType.Success);
+        result.FailureType.ShouldBe(ResultFailureType.None);
+        result.Error.ShouldBeEmpty();
+        result.Failures.ShouldBeEmpty();
+        result.TryGetValue(out string? value).ShouldBeTrue();
+        value.ShouldBe("Test Value");
+    }
+
+    #endregion Success Serialization Tests
+
+    #region General Failure Serialization Tests
+
+    [Fact]
+    public void Serialize_GeneralFailure_ShouldProduceCorrectJson()
+    {
+        // Arrange
+        Result<string> result = Result.Failure<string>("Something went wrong");
+
+        // Act
+        string json = JsonSerializer.Serialize(result, _options);
+
+        // Assert
+        json.ShouldContain("\"error\":\"Something went wrong\"");
+        json.ShouldContain("\"failureType\":\"Error\"");
+        json.ShouldContain("\"resultType\":\"Error\"");
+        json.ShouldContain("\"failures\":{}");
+        json.ShouldNotContain("\"value\":");
+    }
+
+    [Fact]
+    public void Deserialize_GeneralFailureJson_ShouldCreateCorrectResult()
+    {
+        // Arrange
+        string json = @"{
+            ""error"": ""Database connection failed"",
+            ""failures"": {},
+            ""failureType"": ""Error"",
+            ""resultType"": ""Error""
+        }";
+
+        // Act
+        Result<string> result = JsonSerializer.Deserialize<Result<string>>(json, _options)!;
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.IsFailure.ShouldBeTrue();
+        result.IsSuccess.ShouldBeFalse();
+        result.ResultType.ShouldBe(ResultType.Error);
+        result.FailureType.ShouldBe(ResultFailureType.Error);
+        result.Error.ShouldBe("Database connection failed");
+        result.Failures.ShouldBeEmpty();
+        result.TryGetValue(out string? value).ShouldBeFalse();
+        value.ShouldBeNull();
+    }
+
+    #endregion General Failure Serialization Tests
+
+    #region Security Failure Serialization Tests
+
+    [Fact]
+    public void Serialize_SecurityFailure_ShouldProduceCorrectJson()
+    {
+        // Arrange
+        SecurityException ex = new("Access denied");
+        Result<int> result = Result.Failure<int>(ex);
+
+        // Act
+        string json = JsonSerializer.Serialize(result, _options);
+
+        // Assert
+        json.ShouldContain("\"error\":\"Access denied\"");
+        json.ShouldContain("\"failureType\":\"Security\"");
+        json.ShouldContain("\"resultType\":\"Error\"");
+        json.ShouldContain("\"failures\":{}");
+        json.ShouldNotContain("\"value\":");
+    }
+
+    [Fact]
+    public void Deserialize_SecurityFailureJson_ShouldCreateCorrectResult()
+    {
+        // Arrange
+        string json = @"{
+            ""error"": ""Unauthorized access attempt"",
+            ""failures"": {},
+            ""failureType"": ""Security"",
+            ""resultType"": ""Error""
+        }";
+
+        // Act
+        Result<int> result = JsonSerializer.Deserialize<Result<int>>(json, _options)!;
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.IsFailure.ShouldBeTrue();
+        result.ResultType.ShouldBe(ResultType.Error);
+        result.FailureType.ShouldBe(ResultFailureType.Security);
+        result.Error.ShouldBe("Unauthorized access attempt");
+        result.TryGetValue(out int value).ShouldBeFalse();
+        value.ShouldBe(default(int));
+    }
+
+    #endregion Security Failure Serialization Tests
+
+    #region Operation Canceled Serialization Tests
+
+    [Fact]
+    public void Serialize_OperationCanceledFailure_ShouldProduceCorrectJson()
+    {
+        // Arrange
+        OperationCanceledException ex = new("Operation was cancelled");
+        Result<string> result = Result.Failure<string>(ex);
+
+        // Act
+        string json = JsonSerializer.Serialize(result, _options);
+
+        // Assert
+        json.ShouldContain("\"error\":\"Operation was cancelled\"");
+        json.ShouldContain("\"failureType\":\"OperationCanceled\"");
+        json.ShouldContain("\"resultType\":\"Warning\"");
+        json.ShouldContain("\"failures\":{}");
+        json.ShouldNotContain("\"value\":");
+    }
+
+    [Fact]
+    public void Deserialize_OperationCanceledFailureJson_ShouldCreateCorrectResult()
+    {
+        // Arrange
+        string json = @"{
+            ""error"": ""Request timeout"",
+            ""failures"": {},
+            ""failureType"": ""OperationCanceled"",
+            ""resultType"": ""Warning""
+        }";
+
+        // Act
+        Result<string> result = JsonSerializer.Deserialize<Result<string>>(json, _options)!;
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.IsFailure.ShouldBeTrue();
+        result.ResultType.ShouldBe(ResultType.Warning);
+        result.FailureType.ShouldBe(ResultFailureType.OperationCanceled);
+        result.Error.ShouldBe("Request timeout");
+    }
+
+    #endregion Operation Canceled Serialization Tests
+
+    #region Validation Failure Serialization Tests
+
+    [Fact]
+    public void Serialize_ValidationFailure_ShouldProduceCorrectJson()
+    {
+        // Arrange
+        Dictionary<string, string[]> errors = new()
+        {
+            { "Name", ["Name is required", "Name must be at least 2 characters"] },
+            { "Email", ["Email is required", "Email format is invalid"] }
+        };
+        Result<TestUser> result = Result.ValidationFailure<TestUser>(errors);
+
+        // Act
+        string json = JsonSerializer.Serialize(result, _options);
+
+        // Assert
+        json.ShouldContain("\"failureType\":\"Validation\"");
+        json.ShouldContain("\"resultType\":\"Error\"");
+        json.ShouldContain("\"Name\"");
+        json.ShouldContain("\"Name is required\"");
+        json.ShouldContain("\"Email\"");
+        json.ShouldContain("\"Email is required\"");
+        json.ShouldNotContain("\"value\":");
+    }
+
+    [Fact]
+    public void Deserialize_ValidationFailureJson_ShouldCreateCorrectResult()
+    {
+        // Arrange
+        string json = @"{
+            ""error"": ""One or more validation errors occurred.\r\nName\r\n  - Name is required\r\nEmail\r\n  - Email format is invalid"",
+            ""failures"": {
+                ""Name"": [""Name is required""],
+                ""Email"": [""Email format is invalid""]
+            },
+            ""failureType"": ""Validation"",
+            ""resultType"": ""Error""
+        }";
+
+        // Act
+        Result<TestUser> result = JsonSerializer.Deserialize<Result<TestUser>>(json, _options)!;
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.IsFailure.ShouldBeTrue();
+        result.ResultType.ShouldBe(ResultType.Error);
+        result.FailureType.ShouldBe(ResultFailureType.Validation);
+        result.Failures.ShouldNotBeEmpty();
+        result.Failures.Count.ShouldBe(2);
+        result.Failures["Name"].ShouldBe(["Name is required"]);
+        result.Failures["Email"].ShouldBe(["Email format is invalid"]);
+        result.TryGetValue(out TestUser? value).ShouldBeFalse();
+        value.ShouldBeNull();
+    }
+
+    #endregion Validation Failure Serialization Tests
+
+    #region Round-trip Serialization Tests
+
+    [Theory]
+    [MemberData(nameof(GetResultTestCases))]
+    public void RoundTrip_AllResultTypes_ShouldPreserveOriginalState(Result<string> originalResult)
+    {
+        // Act
+        string json = JsonSerializer.Serialize(originalResult, _options);
+        Result<string> deserializedResult = JsonSerializer.Deserialize<Result<string>>(json, _options)!;
+
+        // Assert
+        deserializedResult.ShouldNotBeNull();
+        deserializedResult.IsSuccess.ShouldBe(originalResult.IsSuccess);
+        deserializedResult.IsFailure.ShouldBe(originalResult.IsFailure);
+        deserializedResult.ResultType.ShouldBe(originalResult.ResultType);
+        deserializedResult.FailureType.ShouldBe(originalResult.FailureType);
+        deserializedResult.Error.ShouldBe(originalResult.Error);
+        deserializedResult.Failures.Count.ShouldBe(originalResult.Failures.Count);
+
+        foreach (KeyValuePair<string, string[]> failure in originalResult.Failures)
+        {
+            deserializedResult.Failures.ShouldContainKey(failure.Key);
+            deserializedResult.Failures[failure.Key].ShouldBe(failure.Value);
+        }
+
+        // Test success value
+        bool originalHasValue = originalResult.TryGetValue(out string? originalValue);
+        bool deserializedHasValue = deserializedResult.TryGetValue(out string? deserializedValue);
+
+        originalHasValue.ShouldBe(deserializedHasValue);
+        originalValue.ShouldBe(deserializedValue);
+    }
+
+    [Theory]
+    [MemberData(nameof(GetComplexResultTestCases))]
+    public void RoundTrip_ComplexObjectResults_ShouldPreserveOriginalState(Result<TestUser> originalResult)
+    {
+        // Act
+        string json = JsonSerializer.Serialize(originalResult, _options);
+        Result<TestUser> deserializedResult = JsonSerializer.Deserialize<Result<TestUser>>(json, _options)!;
+
+        // Assert
+        deserializedResult.ShouldNotBeNull();
+        deserializedResult.IsSuccess.ShouldBe(originalResult.IsSuccess);
+        deserializedResult.ResultType.ShouldBe(originalResult.ResultType);
+        deserializedResult.FailureType.ShouldBe(originalResult.FailureType);
+
+        // Test success value for complex objects
+        bool originalHasValue = originalResult.TryGetValue(out TestUser? originalValue);
+        bool deserializedHasValue = deserializedResult.TryGetValue(out TestUser? deserializedValue);
+
+        originalHasValue.ShouldBe(deserializedHasValue);
+        if (originalHasValue)
+        {
+            deserializedValue.ShouldNotBeNull();
+            deserializedValue.Name.ShouldBe(originalValue!.Name);
+            deserializedValue.Email.ShouldBe(originalValue.Email);
+            deserializedValue.Age.ShouldBe(originalValue.Age);
+        }
+    }
+
+    public static TheoryData<Result<string>> GetResultTestCases() =>
+        new()
+        {
+            Result.Success("Hello World"),
+            Result.Success("Info message", ResultType.Information),
+            Result.Failure<string>("General error"),
+            Result.Failure<string>("Custom error", ResultType.Warning, ResultFailureType.Error),
+            Result.Failure<string>(new SecurityException("Security violation")),
+            Result.Failure<string>(new OperationCanceledException("Timeout occurred")),
+            Result.ValidationFailure<string>(new Dictionary<string, string[]>
+            {
+                { "Field1", ["Error 1", "Error 2"] },
+                { "Field2", ["Error 3"] }
+            }),
+            Result.Failure<string>("SingleField", "Single field error")
+        };
+
+    public static TheoryData<Result<TestUser>> GetComplexResultTestCases() =>
+        new()
+        {
+            Result.Success(new TestUser("John", "john@test.com", 25)),
+            Result.Failure<TestUser>("User not found"),
+            Result.ValidationFailure<TestUser>(new Dictionary<string, string[]>
+            {
+                { "Name", ["Name is required"] },
+                { "Email", ["Invalid email format"] }
+            })
+        };
+
+    #endregion Round-trip Serialization Tests
+
+    #region Edge Case Tests
+
+    [Fact]
+    public void Deserialize_EmptyJson_ShouldThrowJsonException()
+    {
+        // Arrange
+        string json = "";
+
+        // Act & Assert
+        Should.Throw<JsonException>(() => JsonSerializer.Deserialize<Result<string>>(json, _options));
+    }
+
+    [Fact]
+    public void Deserialize_InvalidJson_ShouldThrowJsonException()
+    {
+        // Arrange
+        string json = "{ invalid json }";
+
+        // Act & Assert
+        Should.Throw<JsonException>(() => JsonSerializer.Deserialize<Result<string>>(json, _options));
+    }
+
+    [Fact]
+    public void Deserialize_JsonArray_ShouldThrowJsonException()
+    {
+        // Arrange
+        string json = "[]";
+
+        // Act & Assert
+        Should.Throw<JsonException>(() => JsonSerializer.Deserialize<Result<string>>(json, _options));
+    }
+
+    [Fact]
+    public void Deserialize_JsonWithMissingProperties_ShouldCreateDefaultResult()
+    {
+        // Arrange
+        string json = @"{}";
+
+        // Act
+        Result<string> result = JsonSerializer.Deserialize<Result<string>>(json, _options)!;
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.IsFailure.ShouldBeTrue(); // No value provided, so it should be a failure
+        result.Error.ShouldBe("No value provided for Result<T>");
+    }
+
+    [Fact]
+    public void Serialize_NullableStringValue_ShouldProduceCorrectJson()
+    {
+        // Arrange - Create a success result with empty string instead of null
+        Result<string> result = Result.Success(string.Empty);
+
+        // Act
+        string json = JsonSerializer.Serialize(result, _options);
+
+        // Assert
+        json.ShouldContain("\"value\":\"\"");
+        json.ShouldContain("\"resultType\":\"Success\"");
+    }
+
+    [Fact]
+    public void Write_WithNullResult_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        ResultTJsonConverter<string> converter = new();
+        MemoryStream stream = new();
+        Utf8JsonWriter writer = new(stream);
+
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => 
+            converter.Write(writer, null!, _options));
+    }
+
+    [Fact]
+    public void Write_WithNullWriter_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        ResultTJsonConverter<string> converter = new();
+        Result<string> result = Result.Success("test");
+
+        // Act & Assert
+        Should.Throw<ArgumentNullException>(() => 
+            converter.Write(null!, result, _options));
+    }
+
+    #endregion Edge Case Tests
+}


### PR DESCRIPTION
## Summary
- Implemented `ResultTJsonConverter<T>` class with comprehensive JSON serialization support for `Result<T>`
- Added complete test suite with 37 test cases covering all scenarios
- Supports all failure types (Error, Security, Validation, OperationCanceled) and success values
- Maintains round-trip serialization fidelity for both primitive and complex object types

## Test Coverage
- Success serialization with different value types (string, int, complex objects)
- All failure type serializations match non-generic Result pattern
- Round-trip serialization preserves exact state and values
- Edge cases including null handling and invalid JSON
- All 221 existing tests continue to pass

## Implementation Details
- Follows existing `ResultJsonConverter` patterns for consistency
- Includes "value" property only for successful results
- Proper XML documentation following project standards
- Handles type-safe deserialization with appropriate error handling

🤖 Generated with [Claude Code](https://claude.ai/code)