### PR TITLE
feat: complete TASK-038 out parameter support for value extraction

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -84,7 +84,7 @@
 ### Result Integration
 - [x] **TASK-036**: Add RuleFor overload for Result<T> composition
 - [x] **TASK-037**: Implement automatic error extraction from nested Results
-- [ ] **TASK-038**: Create out parameter support for value extraction
+- [x] **TASK-038**: Create out parameter support for value extraction
 - [ ] **TASK-039**: Add validation context for complex scenarios
 - [ ] **TASK-040**: Build custom message support with WithMessage
 

--- a/src/Validation/Builders/ValidationBuilder.cs
+++ b/src/Validation/Builders/ValidationBuilder.cs
@@ -117,6 +117,32 @@ public class ValidationBuilder<T>
         CreateValidator(propertySelector, value, displayName, (builder, display, val) => new GuidPropertyValidator<T>(builder, display, val));
 
     /// <summary>
+    /// Creates validation rules for a Guid? property with out parameter support for value extraction.
+    /// </summary>
+    /// <param name="propertySelector">An expression selecting the property to validate.</param>
+    /// <param name="value">The actual Guid? value to be validated.</param>
+    /// <param name="validatedValue">Output parameter that receives the validated value if validation succeeds, or null if validation fails.</param>
+    /// <param name="displayName">Optional custom display name for error messages.</param>
+    /// <returns>The ValidationBuilder&lt;T&gt; for continued chaining.</returns>
+    public ValidationBuilder<T> RuleFor(Expression<Func<T, Guid?>> propertySelector, Guid? value, out Guid? validatedValue, string? displayName = null)
+    {
+        string propertyName = displayName ?? GetPropertyName(propertySelector);
+        
+        // Perform basic validation for Guid (not null and not empty)
+        if (value is null || value == Guid.Empty)
+        {
+            validatedValue = null;
+            AddError(propertyName, $"{propertyName} must be a valid GUID");
+        }
+        else
+        {
+            validatedValue = value;
+        }
+        
+        return this;
+    }
+
+    /// <summary>
     /// Creates validation rules for a string property using a fluent interface.
     /// </summary>
     /// <param name="propertySelector">An expression selecting the property to validate (e.g., x =&gt; x.Name).</param>
@@ -136,6 +162,48 @@ public class ValidationBuilder<T>
     /// </example>
     public StringPropertyValidator<T> RuleFor(Expression<Func<T, string>> propertySelector, string value, string? displayName = null) =>
         CreateValidator(propertySelector, value, displayName, (builder, display, val) => new StringPropertyValidator<T>(builder, display, val));
+
+    /// <summary>
+    /// Creates validation rules for a string property with out parameter support for value extraction.
+    /// This overload performs basic validation immediately and provides the validated value through the out parameter.
+    /// </summary>
+    /// <param name="propertySelector">An expression selecting the property to validate (e.g., x =&gt; x.Name).</param>
+    /// <param name="value">The actual string value to be validated.</param>
+    /// <param name="validatedValue">Output parameter that receives the validated value if validation succeeds, or null if validation fails.</param>
+    /// <param name="displayName">Optional custom display name for error messages. If null, uses the property name from the expression.</param>
+    /// <returns>The ValidationBuilder&lt;T&gt; for continued chaining of other property validations.</returns>
+    /// <remarks>
+    /// This overload enables extraction of validated values for use in object construction patterns.
+    /// The out parameter will contain the input value if it passes basic validation (not null/empty for strings),
+    /// or null if the basic validation fails.
+    /// For more complex validation rules, use the standard RuleFor overload that returns a property validator.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// ValidationBuilder&lt;User&gt; builder = new();
+    /// builder.RuleFor(x =&gt; x.Name, request.Name, out string? validatedName);
+    /// builder.RuleFor(x =&gt; x.Age, request.Age, out int? validatedAge);
+    ///     
+    /// Result&lt;User&gt; result = builder.Build(() =&gt; new User(validatedName!, validatedAge!.Value, "email"));
+    /// </code>
+    /// </example>
+    public ValidationBuilder<T> RuleFor(Expression<Func<T, string>> propertySelector, string value, out string? validatedValue, string? displayName = null)
+    {
+        string propertyName = displayName ?? GetPropertyName(propertySelector);
+        
+        // Perform basic validation for strings (not null or empty)
+        if (string.IsNullOrEmpty(value))
+        {
+            validatedValue = null;
+            AddError(propertyName, $"{propertyName} is required");
+        }
+        else
+        {
+            validatedValue = value;
+        }
+        
+        return this;
+    }
 
     /// <summary>
     /// Integrates Result&lt;T&gt; validation into the validation builder, automatically extracting failures and providing access to successful values.
@@ -232,6 +300,47 @@ public class ValidationBuilder<T>
         CreateNumericValidator(propertySelector, value, displayName);
 
     /// <summary>
+    /// Creates validation rules for an integer property with out parameter support for value extraction.
+    /// This overload performs basic validation immediately and provides the validated value through the out parameter.
+    /// </summary>
+    /// <param name="propertySelector">An expression selecting the property to validate (e.g., x =&gt; x.Age).</param>
+    /// <param name="value">The actual integer value to be validated.</param>
+    /// <param name="validatedValue">Output parameter that receives the validated value if validation succeeds, or null if validation fails.</param>
+    /// <param name="displayName">Optional custom display name for error messages. If null, uses the property name from the expression.</param>
+    /// <returns>The ValidationBuilder&lt;T&gt; for continued chaining of other property validations.</returns>
+    /// <remarks>
+    /// This overload enables extraction of validated values for use in object construction patterns.
+    /// The out parameter will contain the input value if it passes basic validation (greater than or equal to 0),
+    /// or null if the basic validation fails.
+    /// For more complex validation rules, use the standard RuleFor overload that returns a property validator.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// ValidationBuilder&lt;User&gt; builder = new();
+    /// builder.RuleFor(x =&gt; x.Age, request.Age, out int? validatedAge);
+    ///     
+    /// Result&lt;User&gt; result = builder.Build(() =&gt; new User("name", "email", validatedAge!.Value));
+    /// </code>
+    /// </example>
+    public ValidationBuilder<T> RuleFor(Expression<Func<T, int>> propertySelector, int value, out int? validatedValue, string? displayName = null)
+    {
+        string propertyName = displayName ?? GetPropertyName(propertySelector);
+        
+        // Perform basic validation for integers (greater than or equal to 0)
+        if (value < 0)
+        {
+            validatedValue = null;
+            AddError(propertyName, $"{propertyName} must be greater than or equal to 0");
+        }
+        else
+        {
+            validatedValue = value;
+        }
+        
+        return this;
+    }
+
+    /// <summary>
     /// Creates validation rules for a long numeric property using a fluent interface.
     /// </summary>
     /// <param name="propertySelector">Expression selecting the property to validate.</param>
@@ -250,6 +359,32 @@ public class ValidationBuilder<T>
     /// <returns>A numeric property validator for further rule configuration.</returns>
     public NumericPropertyValidator<T, decimal> RuleFor(Expression<Func<T, decimal>> propertySelector, decimal value, string? displayName = null) =>
         CreateNumericValidator(propertySelector, value, displayName);
+
+    /// <summary>
+    /// Creates validation rules for a decimal property with out parameter support for value extraction.
+    /// </summary>
+    /// <param name="propertySelector">An expression selecting the property to validate.</param>
+    /// <param name="value">The actual decimal value to be validated.</param>
+    /// <param name="validatedValue">Output parameter that receives the validated value if validation succeeds, or null if validation fails.</param>
+    /// <param name="displayName">Optional custom display name for error messages.</param>
+    /// <returns>The ValidationBuilder&lt;T&gt; for continued chaining.</returns>
+    public ValidationBuilder<T> RuleFor(Expression<Func<T, decimal>> propertySelector, decimal value, out decimal? validatedValue, string? displayName = null)
+    {
+        string propertyName = displayName ?? GetPropertyName(propertySelector);
+        
+        // Perform basic validation for decimals (greater than or equal to 0)
+        if (value < 0)
+        {
+            validatedValue = null;
+            AddError(propertyName, $"{propertyName} must be greater than or equal to 0");
+        }
+        else
+        {
+            validatedValue = value;
+        }
+        
+        return this;
+    }
 
     /// <summary>
     /// Creates validation rules for a double numeric property using a fluent interface.
@@ -304,6 +439,33 @@ public class ValidationBuilder<T>
         CreateValidator(propertySelector, value, displayName, (builder, display, val) => new EnumerablePropertyValidator<T, TItem>(builder, display, val));
 
     /// <summary>
+    /// Creates validation rules for an enumerable property with out parameter support for value extraction.
+    /// </summary>
+    /// <typeparam name="TItem">The type of items in the enumerable.</typeparam>
+    /// <param name="propertySelector">An expression selecting the property to validate.</param>
+    /// <param name="value">The actual enumerable value to be validated.</param>
+    /// <param name="validatedValue">Output parameter that receives the validated value if validation succeeds, or null if validation fails.</param>
+    /// <param name="displayName">Optional custom display name for error messages.</param>
+    /// <returns>The ValidationBuilder&lt;T&gt; for continued chaining.</returns>
+    public ValidationBuilder<T> RuleFor<TItem>(Expression<Func<T, IEnumerable<TItem>>> propertySelector, IEnumerable<TItem> value, out IEnumerable<TItem>? validatedValue, string? displayName = null)
+    {
+        string propertyName = displayName ?? GetPropertyName(propertySelector);
+        
+        // Perform basic validation for enumerables (not null)
+        if (value is null)
+        {
+            validatedValue = null;
+            AddError(propertyName, $"{propertyName} cannot be null");
+        }
+        else
+        {
+            validatedValue = value;
+        }
+        
+        return this;
+    }
+
+    /// <summary>
     /// Creates validation rules for any property type using a fluent interface. This is the fallback validator for types
     /// that don't have specialized validators (string, numeric, enumerable, guid).
     /// </summary>
@@ -344,6 +506,32 @@ public class ValidationBuilder<T>
         CreateValidator(propertySelector, value, displayName, (builder, display, val) => new GenericPropertyValidator<T, DateTime>(builder, display, val));
 
     /// <summary>
+    /// Creates validation rules for a DateTime property with out parameter support for value extraction.
+    /// </summary>
+    /// <param name="propertySelector">An expression selecting the property to validate.</param>
+    /// <param name="value">The actual DateTime value to be validated.</param>
+    /// <param name="validatedValue">Output parameter that receives the validated value if validation succeeds, or null if validation fails.</param>
+    /// <param name="displayName">Optional custom display name for error messages.</param>
+    /// <returns>The ValidationBuilder&lt;T&gt; for continued chaining.</returns>
+    public ValidationBuilder<T> RuleFor(Expression<Func<T, DateTime>> propertySelector, DateTime value, out DateTime? validatedValue, string? displayName = null)
+    {
+        string propertyName = displayName ?? GetPropertyName(propertySelector);
+        
+        // Perform basic validation for DateTime (not default)
+        if (value == default)
+        {
+            validatedValue = null;
+            AddError(propertyName, $"{propertyName} must be a valid date");
+        }
+        else
+        {
+            validatedValue = value;
+        }
+        
+        return this;
+    }
+
+    /// <summary>
     /// Creates validation rules for a nullable DateTime property using a fluent interface.
     /// </summary>
     /// <param name="propertySelector">An expression selecting the property to validate (e.g., x =&gt; x.UpdatedAt).</param>
@@ -379,6 +567,21 @@ public class ValidationBuilder<T>
     /// </example>
     public GenericPropertyValidator<T, bool> RuleFor(Expression<Func<T, bool>> propertySelector, bool value, string? displayName = null) =>
         CreateValidator(propertySelector, value, displayName, (builder, display, val) => new GenericPropertyValidator<T, bool>(builder, display, val));
+
+    /// <summary>
+    /// Creates validation rules for a boolean property with out parameter support for value extraction.
+    /// </summary>
+    /// <param name="propertySelector">An expression selecting the property to validate.</param>
+    /// <param name="value">The actual boolean value to be validated.</param>
+    /// <param name="validatedValue">Output parameter that receives the validated value.</param>
+    /// <param name="displayName">Optional custom display name for error messages.</param>
+    /// <returns>The ValidationBuilder&lt;T&gt; for continued chaining.</returns>
+    public ValidationBuilder<T> RuleFor(Expression<Func<T, bool>> propertySelector, bool value, out bool? validatedValue, string? displayName = null)
+    {
+        // Boolean values are always valid
+        validatedValue = value;
+        return this;
+    }
 
     /// <summary>
     /// Creates validation rules for a nullable boolean property using a fluent interface.

--- a/tests/Validation.Tests/Builders/OutParameterSupportTests.cs
+++ b/tests/Validation.Tests/Builders/OutParameterSupportTests.cs
@@ -1,0 +1,315 @@
+using FlowRight.Core.Results;
+using FlowRight.Validation.Builders;
+using FlowRight.Validation.Tests.TestModels;
+using Shouldly;
+
+namespace FlowRight.Validation.Tests.Builders;
+
+/// <summary>
+/// Test suite for TASK-038: Out parameter support for value extraction in ValidationBuilder&lt;T&gt;.
+/// These tests define the expected behavior for extracting validated values through out parameters
+/// on all RuleFor method overloads, enabling cleaner object construction patterns.
+/// 
+/// Following TDD principles - these tests will initially fail until implementation is complete.
+/// </summary>
+public class OutParameterSupportTests
+{
+    #region String Property Out Parameter Tests
+    
+    /// <summary>
+    /// Tests for string property validation with out parameter support
+    /// </summary>
+    public class StringPropertyOutParameters
+    {
+        [Fact]
+        public void RuleFor_StringProperty_WithOutParameter_ShouldProvideValidatedValue()
+        {
+            // Arrange
+            ValidationBuilder<User> builder = new();
+            string inputName = "John Doe";
+
+            // Act
+            builder.RuleFor(u => u.Name, inputName, out string? validatedName);
+
+            Result<User> result = builder.Build(() => new User(validatedName!, "john@example.com", 25, Guid.NewGuid(), []));
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+            validatedName.ShouldBe(inputName);
+            result.TryGetValue(out User? user).ShouldBeTrue();
+            user.Name.ShouldBe(inputName);
+        }
+
+        [Fact]
+        public void RuleFor_StringProperty_WithValidationFailure_ShouldProvideNullValue()
+        {
+            // Arrange
+            ValidationBuilder<User> builder = new();
+            string inputName = "";
+
+            // Act
+            builder.RuleFor(u => u.Name, inputName, out string? validatedName);
+
+            Result<User> result = builder.Build(() => new User(validatedName ?? "Default", "john@example.com", 25, Guid.NewGuid(), []));
+
+            // Assert
+            result.IsFailure.ShouldBeTrue();
+            validatedName.ShouldBeNull();
+        }
+    }
+
+    #endregion
+
+    #region Numeric Property Out Parameter Tests
+    
+    /// <summary>
+    /// Tests for numeric property validation with out parameter support
+    /// </summary>
+    public class NumericPropertyOutParameters
+    {
+        [Fact]
+        public void RuleFor_IntProperty_WithOutParameter_ShouldProvideValidatedValue()
+        {
+            // Arrange
+            ValidationBuilder<User> builder = new();
+            int inputAge = 30;
+
+            // Act
+            builder.RuleFor(u => u.Age, inputAge, out int? validatedAge);
+
+            Result<User> result = builder.Build(() => new User("John", "john@example.com", validatedAge!.Value, Guid.NewGuid(), []));
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+            validatedAge.ShouldBe(inputAge);
+            result.TryGetValue(out User? user1).ShouldBeTrue();
+            user1.Age.ShouldBe(inputAge);
+        }
+
+        [Fact]
+        public void RuleFor_IntProperty_WithValidationFailure_ShouldProvideNullValue()
+        {
+            // Arrange
+            ValidationBuilder<User> builder = new();
+            int inputAge = -5; // Invalid: less than 0
+
+            // Act
+            builder.RuleFor(u => u.Age, inputAge, out int? validatedAge);
+
+            Result<User> result = builder.Build(() => new User("John", "john@example.com", validatedAge ?? 0, Guid.NewGuid(), []));
+
+            // Assert
+            result.IsFailure.ShouldBeTrue();
+            validatedAge.ShouldBeNull();
+        }
+
+        [Fact]
+        public void RuleFor_DecimalProperty_WithOutParameter_ShouldProvideValidatedValue()
+        {
+            // Arrange
+            ValidationBuilder<TestEntity> builder = new();
+            decimal inputValue = 123.45m;
+
+            // Act
+            builder.RuleFor(e => e.DecimalValue, inputValue, out decimal? validatedValue);
+
+            Result<TestEntity> result = builder.Build(() => new TestEntity { DecimalValue = validatedValue!.Value });
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+            validatedValue.ShouldBe(inputValue);
+            result.TryGetValue(out TestEntity? entity1).ShouldBeTrue();
+            entity1.DecimalValue.ShouldBe(inputValue);
+        }
+    }
+
+    #endregion
+
+    #region Generic Property Out Parameter Tests
+    
+    /// <summary>
+    /// Tests for generic property validation with out parameter support
+    /// </summary>
+    public class GenericPropertyOutParameters
+    {
+        [Fact]
+        public void RuleFor_BoolProperty_WithOutParameter_ShouldProvideValidatedValue()
+        {
+            // Arrange
+            ValidationBuilder<TestEntity> builder = new();
+            bool inputValue = true;
+
+            // Act
+            builder.RuleFor(e => e.IsActive, inputValue, out bool? validatedValue);
+
+            Result<TestEntity> result = builder.Build(() => new TestEntity { IsActive = validatedValue!.Value });
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+            validatedValue.ShouldBe(inputValue);
+            result.TryGetValue(out TestEntity? entity2).ShouldBeTrue();
+            entity2.IsActive.ShouldBe(inputValue);
+        }
+
+        [Fact]
+        public void RuleFor_DateTimeProperty_WithOutParameter_ShouldProvideValidatedValue()
+        {
+            // Arrange
+            ValidationBuilder<TestEntity> builder = new();
+            DateTime inputValue = new(2024, 1, 1);
+
+            // Act
+            builder.RuleFor(e => e.CreatedAt, inputValue, out DateTime? validatedValue);
+
+            Result<TestEntity> result = builder.Build(() => new TestEntity { CreatedAt = validatedValue!.Value });
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+            validatedValue.ShouldBe(inputValue);
+            result.TryGetValue(out TestEntity? entity3).ShouldBeTrue();
+            entity3.CreatedAt.ShouldBe(inputValue);
+        }
+    }
+
+    #endregion
+
+    #region Enumerable Property Out Parameter Tests
+    
+    /// <summary>
+    /// Tests for enumerable property validation with out parameter support
+    /// </summary>
+    public class EnumerablePropertyOutParameters
+    {
+        [Fact]
+        public void RuleFor_EnumerableProperty_WithOutParameter_ShouldProvideValidatedValue()
+        {
+            // Arrange
+            ValidationBuilder<User> builder = new();
+            IEnumerable<string> inputRoles = ["Admin", "User"];
+
+            // Act
+            builder.RuleFor(u => u.Roles, inputRoles, out IEnumerable<string>? validatedRoles);
+
+            Result<User> result = builder.Build(() => new User("John", "john@example.com", 25, Guid.NewGuid(), validatedRoles!));
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+            validatedRoles.ShouldNotBeNull();
+            validatedRoles.ShouldBe(inputRoles);
+            result.TryGetValue(out User? user2).ShouldBeTrue();
+            user2.Roles.ShouldBe(inputRoles);
+        }
+    }
+
+    #endregion
+
+    #region Guid Property Out Parameter Tests
+    
+    /// <summary>
+    /// Tests for Guid property validation with out parameter support
+    /// </summary>
+    public class GuidPropertyOutParameters
+    {
+        [Fact]
+        public void RuleFor_GuidProperty_WithOutParameter_ShouldProvideValidatedValue()
+        {
+            // Arrange
+            ValidationBuilder<TestEntity> builder = new();
+            Guid inputId = Guid.NewGuid();
+
+            // Act
+            builder.RuleFor(e => e.Id, inputId, out Guid? validatedId);
+
+            Result<TestEntity> result = builder.Build(() => new TestEntity { Id = validatedId!.Value });
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+            validatedId.ShouldBe(inputId);
+            result.TryGetValue(out TestEntity? entity4).ShouldBeTrue();
+            entity4.Id.ShouldBe(inputId);
+        }
+    }
+
+    #endregion
+
+    #region Complex Composition Tests
+    
+    /// <summary>
+    /// Tests for complex validation composition with multiple out parameters
+    /// </summary>
+    public class ComplexCompositionTests
+    {
+        [Fact]
+        public void RuleFor_MultipleOutParameters_ShouldProvideAllValidatedValues()
+        {
+            // Arrange
+            ValidationBuilder<User> builder = new();
+            string inputName = "John Doe";
+            int inputAge = 30;
+            string inputEmail = "john@example.com";
+
+            // Act
+            builder.RuleFor(u => u.Name, inputName, out string? validatedName);
+            builder.RuleFor(u => u.Age, inputAge, out int? validatedAge);
+            builder.RuleFor(u => u.Email, inputEmail, out string? validatedEmail);
+
+            Result<User> result = builder.Build(() => new User(validatedName!, validatedEmail!, validatedAge!.Value, Guid.NewGuid(), []));
+
+            // Assert
+            result.IsSuccess.ShouldBeTrue();
+            validatedName.ShouldBe(inputName);
+            validatedAge.ShouldBe(inputAge);
+            validatedEmail.ShouldBe(inputEmail);
+            
+            result.TryGetValue(out User? user3).ShouldBeTrue();
+            user3.Name.ShouldBe(inputName);
+            user3.Age.ShouldBe(inputAge);
+            user3.Email.ShouldBe(inputEmail);
+        }
+
+        [Fact]
+        public void RuleFor_MixedSuccessAndFailure_ShouldProvideCorrectValues()
+        {
+            // Arrange
+            ValidationBuilder<User> builder = new();
+            string inputName = "John"; // Valid
+            int inputAge = -5;         // Invalid
+            string inputEmail = "john@example.com"; // Valid
+
+            // Act
+            builder.RuleFor(u => u.Name, inputName, out string? validatedName);
+            builder.RuleFor(u => u.Age, inputAge, out int? validatedAge);
+            builder.RuleFor(u => u.Email, inputEmail, out string? validatedEmail);
+
+            Result<User> result = builder.Build(() => new User(
+                validatedName ?? "Default", 
+                validatedEmail ?? "default@example.com",
+                validatedAge ?? 0,
+                Guid.NewGuid(),
+                []));
+
+            // Assert
+            result.IsFailure.ShouldBeTrue();
+            
+            // Valid values should be provided
+            validatedName.ShouldBe(inputName);
+            validatedEmail.ShouldBe(inputEmail);
+            
+            // Invalid values should be null
+            validatedAge.ShouldBeNull();
+        }
+    }
+
+    #endregion
+}
+
+/// <summary>
+/// Test entity for validation testing
+/// </summary>
+public class TestEntity
+{
+    public Guid? Id { get; set; }
+    public decimal DecimalValue { get; set; }
+    public bool IsActive { get; set; }
+    public DateTime CreatedAt { get; set; }
+}


### PR DESCRIPTION
## Summary
- Add out parameter overloads to ValidationBuilder<T> RuleFor methods for key property types
- Enable cleaner object construction patterns with automatic value extraction
- Support for string, int, decimal, bool, DateTime, IEnumerable<T>, and Guid? properties
- Out parameters are set to null when validation fails, contain values when validation succeeds

## Test plan
- [x] Build succeeds without compilation errors
- [x] Comprehensive test suite in OutParameterSupportTests.cs covering all property types
- [x] Validation scenarios for both success and failure cases
- [x] Integration with existing Result<T> pattern
- [x] TASKS.md updated to mark TASK-038 as complete

🤖 Generated with [Claude Code](https://claude.ai/code)