### PR TITLE
feat: complete TASK-042 with comprehensive HttpResponseMessageExtensions tests

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -94,7 +94,7 @@
 
 ### HTTP Extensions
 - [ ] **TASK-041**: Create HttpResponseMessageExtensions class
-- [ ] **TASK-042**: Implement ToResultAsync for non-generic Result
+- [x] **TASK-042**: Implement ToResultAsync for non-generic Result
 - [ ] **TASK-043**: Add ToResultFromJsonAsync for Result<T>
 - [ ] **TASK-044**: Support JsonTypeInfo for AOT scenarios
 - [ ] **TASK-045**: Handle different content types appropriately

--- a/tests/Http.Tests/Extensions/HttpResponseMessageExtensionsTests.cs
+++ b/tests/Http.Tests/Extensions/HttpResponseMessageExtensionsTests.cs
@@ -1,0 +1,368 @@
+using FlowRight.Core.Results;
+using FlowRight.Http.Extensions;
+using FlowRight.Http.Models;
+using Shouldly;
+using System.Net;
+using System.Net.Mime;
+using System.Security;
+using System.Text;
+using System.Text.Json;
+using Xunit;
+
+namespace FlowRight.Http.Tests.Extensions;
+
+/// <summary>
+/// Tests for HttpResponseMessageExtensions class.
+/// </summary>
+public sealed class HttpResponseMessageExtensionsTests
+{
+    #region ToResultAsync Tests
+
+    [Fact]
+    public async Task ToResultAsync_WithSuccessStatusCode_ReturnsSuccessResult()
+    {
+        // Arrange
+        using HttpResponseMessage response = new(HttpStatusCode.OK);
+
+        // Act
+        Result result = await response.ToResultAsync();
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ToResultAsync_WithCreatedStatusCode_ReturnsSuccessResult()
+    {
+        // Arrange
+        using HttpResponseMessage response = new(HttpStatusCode.Created);
+
+        // Act
+        Result result = await response.ToResultAsync();
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task ToResultAsync_WithBadRequest_ReturnsFailureResult()
+    {
+        // Arrange
+        using HttpResponseMessage response = new(HttpStatusCode.BadRequest)
+        {
+            Content = new StringContent("Bad request error", Encoding.UTF8, MediaTypeNames.Text.Plain)
+        };
+
+        // Act
+        Result result = await response.ToResultAsync();
+
+        // Assert
+        result.IsSuccess.ShouldBeFalse();
+        result.Error.ShouldBe("Bad request error");
+    }
+
+    [Fact]
+    public async Task ToResultAsync_WithBadRequestAndValidationProblem_ReturnsFailureResultWithErrors()
+    {
+        // Arrange
+        ValidationProblemResponse problemResponse = new()
+        {
+            Errors = new Dictionary<string, string[]>
+            {
+                ["Name"] = ["Name is required", "Name must be at least 2 characters"],
+                ["Email"] = ["Invalid email format"]
+            }
+        };
+
+        string jsonContent = JsonSerializer.Serialize(problemResponse, ValidationProblemJsonSerializerContext.Default.ValidationProblemResponse);
+
+        using HttpResponseMessage response = new(HttpStatusCode.BadRequest)
+        {
+            Content = new StringContent(jsonContent, Encoding.UTF8, MediaTypeNames.Application.ProblemJson)
+        };
+
+        // Act
+        Result result = await response.ToResultAsync();
+
+        // Assert
+        result.IsSuccess.ShouldBeFalse();
+        result.Failures.ShouldNotBeNull();
+        result.Failures.Count.ShouldBe(2);
+        result.Failures["Name"].ShouldBe(["Name is required", "Name must be at least 2 characters"]);
+        result.Failures["Email"].ShouldBe(["Invalid email format"]);
+    }
+
+    [Fact]
+    public async Task ToResultAsync_WithUnauthorized_ReturnsFailureResultWithSecurityException()
+    {
+        // Arrange
+        using HttpResponseMessage response = new(HttpStatusCode.Unauthorized);
+
+        // Act
+        Result result = await response.ToResultAsync();
+
+        // Assert
+        result.IsSuccess.ShouldBeFalse();
+        result.FailureType.ShouldBe(ResultFailureType.Security);
+        result.Error.ShouldBe("Unauthorized");
+    }
+
+    [Fact]
+    public async Task ToResultAsync_WithForbidden_ReturnsFailureResultWithSecurityException()
+    {
+        // Arrange
+        using HttpResponseMessage response = new(HttpStatusCode.Forbidden);
+
+        // Act
+        Result result = await response.ToResultAsync();
+
+        // Assert
+        result.IsSuccess.ShouldBeFalse();
+        result.FailureType.ShouldBe(ResultFailureType.Security);
+        result.Error.ShouldBe("Unauthorized");
+    }
+
+    [Fact]
+    public async Task ToResultAsync_WithNotFound_ReturnsFailureResult()
+    {
+        // Arrange
+        using HttpResponseMessage response = new(HttpStatusCode.NotFound);
+
+        // Act
+        Result result = await response.ToResultAsync();
+
+        // Assert
+        result.IsSuccess.ShouldBeFalse();
+        result.Error.ShouldBe("Not Found");
+    }
+
+    [Fact]
+    public async Task ToResultAsync_WithInternalServerError_ReturnsFailureResult()
+    {
+        // Arrange
+        using HttpResponseMessage response = new(HttpStatusCode.InternalServerError);
+
+        // Act
+        Result result = await response.ToResultAsync();
+
+        // Assert
+        result.IsSuccess.ShouldBeFalse();
+        result.Error.ShouldBe("Internal Server Error");
+    }
+
+    [Fact]
+    public async Task ToResultAsync_WithUnexpectedStatusCode_ReturnsFailureResultWithStatusAndBody()
+    {
+        // Arrange
+        using HttpResponseMessage response = new(HttpStatusCode.ServiceUnavailable)
+        {
+            Content = new StringContent("Service temporarily unavailable", Encoding.UTF8, MediaTypeNames.Text.Plain)
+        };
+
+        // Act
+        Result result = await response.ToResultAsync();
+
+        // Assert
+        result.IsSuccess.ShouldBeFalse();
+        result.Error.ShouldBe("Unexpected ServiceUnavailable: Service temporarily unavailable");
+    }
+
+    [Fact]
+    public async Task ToResultAsync_WithNullResponseMessage_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await ((HttpResponseMessage)null!).ToResultAsync());
+    }
+
+    [Fact]
+    public async Task ToResultAsync_WithCancellationToken_ProperlyCancels()
+    {
+        // Arrange
+        using HttpResponseMessage response = new(HttpStatusCode.OK);
+        using CancellationTokenSource cts = new();
+        cts.Cancel();
+
+        // Act & Assert
+        await Should.ThrowAsync<OperationCanceledException>(async () =>
+            await response.ToResultAsync(cts.Token));
+    }
+
+    #endregion ToResultAsync Tests
+
+    #region ToResultFromJsonAsync Tests
+
+    [Fact]
+    public async Task ToResultFromJsonAsync_WithSuccessStatusCodeAndValidJson_ReturnsSuccessResultWithValue()
+    {
+        // Arrange
+        TestModel expected = new() { Id = 1, Name = "Test" };
+        string jsonContent = JsonSerializer.Serialize(expected);
+
+        using HttpResponseMessage response = new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(jsonContent, Encoding.UTF8, MediaTypeNames.Application.Json)
+        };
+
+        // Act
+        Result<TestModel?> result = await response.ToResultFromJsonAsync<TestModel>();
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.TryGetValue(out TestModel? value).ShouldBeTrue();
+        value.ShouldNotBeNull();
+        value.Id.ShouldBe(expected.Id);
+        value.Name.ShouldBe(expected.Name);
+    }
+
+    [Fact]
+    public async Task ToResultFromJsonAsync_WithSuccessStatusCodeAndEmptyJson_ReturnsSuccessResultWithNull()
+    {
+        // Arrange
+        using HttpResponseMessage response = new(HttpStatusCode.OK)
+        {
+            Content = new StringContent("null", Encoding.UTF8, MediaTypeNames.Application.Json)
+        };
+
+        // Act
+        Result<TestModel?> result = await response.ToResultFromJsonAsync<TestModel>();
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.TryGetValue(out TestModel? value).ShouldBeTrue();
+        value.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task ToResultFromJsonAsync_WithBadRequestAndValidationProblem_ReturnsFailureResultWithErrors()
+    {
+        // Arrange
+        ValidationProblemResponse problemResponse = new()
+        {
+            Errors = new Dictionary<string, string[]>
+            {
+                ["Name"] = ["Name is required"],
+                ["Email"] = ["Invalid email format"]
+            }
+        };
+
+        string jsonContent = JsonSerializer.Serialize(problemResponse, ValidationProblemJsonSerializerContext.Default.ValidationProblemResponse);
+
+        using HttpResponseMessage response = new(HttpStatusCode.BadRequest)
+        {
+            Content = new StringContent(jsonContent, Encoding.UTF8, MediaTypeNames.Application.ProblemJson)
+        };
+
+        // Act
+        Result<TestModel?> result = await response.ToResultFromJsonAsync<TestModel>();
+
+        // Assert
+        result.IsSuccess.ShouldBeFalse();
+        result.Failures.ShouldNotBeNull();
+        result.Failures.Count.ShouldBe(2);
+        result.Failures["Name"].ShouldBe(["Name is required"]);
+        result.Failures["Email"].ShouldBe(["Invalid email format"]);
+    }
+
+    [Fact]
+    public async Task ToResultFromJsonAsync_WithUnauthorized_ReturnsFailureResultWithSecurityException()
+    {
+        // Arrange
+        using HttpResponseMessage response = new(HttpStatusCode.Unauthorized);
+
+        // Act
+        Result<TestModel?> result = await response.ToResultFromJsonAsync<TestModel>();
+
+        // Assert
+        result.IsSuccess.ShouldBeFalse();
+        result.FailureType.ShouldBe(ResultFailureType.Security);
+        result.Error.ShouldBe("Unauthorized");
+    }
+
+    [Fact]
+    public async Task ToResultFromJsonAsync_WithNotFound_ReturnsFailureResult()
+    {
+        // Arrange
+        using HttpResponseMessage response = new(HttpStatusCode.NotFound);
+
+        // Act
+        Result<TestModel?> result = await response.ToResultFromJsonAsync<TestModel>();
+
+        // Assert
+        result.IsSuccess.ShouldBeFalse();
+        result.Error.ShouldBe("Not Found");
+    }
+
+    [Fact]
+    public async Task ToResultFromJsonAsync_WithNullResponseMessage_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await ((HttpResponseMessage)null!).ToResultFromJsonAsync<TestModel>());
+    }
+
+    #endregion ToResultFromJsonAsync Tests
+
+    #region ToResultFromJsonAsync with JsonTypeInfo Tests
+
+    [Fact]
+    public async Task ToResultFromJsonAsync_WithJsonTypeInfo_ReturnsSuccessResultWithValue()
+    {
+        // Arrange
+        TestModel expected = new() { Id = 1, Name = "Test" };
+        string jsonContent = JsonSerializer.Serialize(expected, TestModelJsonContext.Default.TestModel);
+
+        using HttpResponseMessage response = new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(jsonContent, Encoding.UTF8, MediaTypeNames.Application.Json)
+        };
+
+        // Act
+        Result<TestModel?> result = await response.ToResultFromJsonAsync(TestModelJsonContext.Default.TestModel);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue();
+        result.TryGetValue(out TestModel? value).ShouldBeTrue();
+        value.ShouldNotBeNull();
+        value.Id.ShouldBe(expected.Id);
+        value.Name.ShouldBe(expected.Name);
+    }
+
+    [Fact]
+    public async Task ToResultFromJsonAsync_WithJsonTypeInfoAndBadRequest_ReturnsFailureResultWithErrors()
+    {
+        // Arrange
+        ValidationProblemResponse problemResponse = new()
+        {
+            Errors = new Dictionary<string, string[]>
+            {
+                ["Name"] = ["Name is required"]
+            }
+        };
+
+        string jsonContent = JsonSerializer.Serialize(problemResponse, ValidationProblemJsonSerializerContext.Default.ValidationProblemResponse);
+
+        using HttpResponseMessage response = new(HttpStatusCode.BadRequest)
+        {
+            Content = new StringContent(jsonContent, Encoding.UTF8, MediaTypeNames.Application.ProblemJson)
+        };
+
+        // Act
+        Result<TestModel?> result = await response.ToResultFromJsonAsync(TestModelJsonContext.Default.TestModel);
+
+        // Assert
+        result.IsSuccess.ShouldBeFalse();
+        result.Failures.ShouldNotBeNull();
+        result.Failures["Name"].ShouldBe(["Name is required"]);
+    }
+
+    [Fact]
+    public async Task ToResultFromJsonAsync_WithJsonTypeInfoAndNullResponseMessage_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        await Should.ThrowAsync<ArgumentNullException>(async () =>
+            await ((HttpResponseMessage)null!).ToResultFromJsonAsync(TestModelJsonContext.Default.TestModel));
+    }
+
+    #endregion ToResultFromJsonAsync with JsonTypeInfo Tests
+}

--- a/tests/Http.Tests/Extensions/TestModelJsonContext.cs
+++ b/tests/Http.Tests/Extensions/TestModelJsonContext.cs
@@ -1,0 +1,20 @@
+using System.Text.Json.Serialization;
+
+namespace FlowRight.Http.Tests.Extensions;
+
+/// <summary>
+/// JsonSerializerContext for test models used in HttpResponseMessageExtensions tests.
+/// </summary>
+[JsonSerializable(typeof(TestModel))]
+internal sealed partial class TestModelJsonContext : JsonSerializerContext
+{
+}
+
+/// <summary>
+/// Test model for JSON serialization testing.
+/// </summary>
+internal sealed class TestModel
+{
+    public int Id { get; init; }
+    public string Name { get; init; } = string.Empty;
+}


### PR DESCRIPTION
## Summary
- Add comprehensive test suite for HttpResponseMessageExtensions covering all ToResultAsync and ToResultFromJsonAsync methods
- Test all HTTP status code mappings (2xx success, 400 validation, 401/403 security, 404 not found, 5xx server errors)
- Verify ValidationProblemDetails handling with proper error aggregation
- Test JsonTypeInfo support for AOT scenarios with source generators
- Update TASKS.md to mark TASK-042 as complete

## Technical Details
The ToResultAsync method for non-generic Result was already implemented in HttpResponseMessageExtensions.cs. This PR adds the missing comprehensive test coverage to ensure all functionality works correctly, including:

- Success scenarios with various 2xx status codes
- Validation error handling with ValidationProblemDetails
- Security exception mapping for 401/403 responses  
- Standard error responses for 404 and 5xx status codes
- JSON deserialization with both JsonSerializerOptions and JsonTypeInfo
- Proper cancellation token support
- Argument null checking

## Test Plan
- [x] All Http.Tests build successfully
- [x] New tests cover all public methods in HttpResponseMessageExtensions
- [x] Tests validate correct Result API usage (Failures, TryGetValue, FailureType)
- [x] JsonTypeInfo tests use source generator context for AOT compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)