### PR TITLE
fix: update GitHub Actions workflows to use .NET 9.0

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ['8.0.x']
+        dotnet-version: ['9.0.x']
 
     steps:
     - uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
       run: dotnet test --configuration Release --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./coverage
 
     - name: Upload coverage reports to Codecov
-      if: matrix.dotnet-version == '8.0.x'
+      if: matrix.dotnet-version == '9.0.x'
       uses: codecov/codecov-action@v4
       with:
         directory: ./coverage
@@ -55,7 +55,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
 
     - name: Restore dependencies
       run: dotnet restore
@@ -77,7 +77,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
 
     - name: Restore dependencies
       run: dotnet restore

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Setup .NET 8.0
+    - name: Setup .NET 9.0
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
 
     - name: Update dependencies
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,10 @@ jobs:
         with:
           node-version: '18'
       
-      - name: Setup .NET 8.0
+      - name: Setup .NET 9.0
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 9.0.x
       
       - name: Install semantic-release
         run: |


### PR DESCRIPTION
## Summary
- Updated all GitHub Actions workflows to use .NET 9.0 instead of 8.0
- Resolves release workflow failures caused by .NET version mismatch

## Problem
The project targets `net9.0` (defined in Directory.Build.props) but the CI/CD workflows were configured to use .NET 8.0.x, causing build and release failures.

## Solution
Updated .NET version in three workflow files:
- `.github/workflows/release.yml` - Changed from 8.0.x to 9.0.x
- `.github/workflows/build-and-test.yml` - Updated matrix and all references
- `.github/workflows/dependency-update.yml` - Updated setup step

## Test plan
- [x] Verified project targets `net9.0` in Directory.Build.props:3
- [x] Confirmed `dotnet build --configuration Release` passes  
- [x] Validated `dotnet test --configuration Release` passes (609 tests)
- [x] All workflow files now consistently use `dotnet-version: 9.0.x`

This should resolve the GitHub Actions release failures.

🤖 Generated with [Claude Code](https://claude.ai/code)